### PR TITLE
Explicitly add routes for IPv4 and IPv6

### DIFF
--- a/bin/namespaced-wireguard-vpn-interface
+++ b/bin/namespaced-wireguard-vpn-interface
@@ -23,7 +23,10 @@ case "$1" in
                 ip -n "$NETNS_NAME" address add '{}' dev "$WIREGUARD_NAME" || die
 
         ip -n "$NETNS_NAME" link set "$WIREGUARD_NAME" up || die
-        ip -n "$NETNS_NAME" route add default dev "$WIREGUARD_NAME" || die
+
+        # Add default routes for IPv4 and IPv6
+        ip -n "$NETNS_NAME" -4 route add default dev "$WIREGUARD_NAME" || die
+        ip -n "$NETNS_NAME" -6 route add default dev "$WIREGUARD_NAME" || die
         ;;
 
     down)


### PR DESCRIPTION
To support routing IPv6 on the Wireguard interface we need to add a default route for IPv6. We currently add a default route, which is implicitly IPv4, so we'll change that to be explicitly IPv4 now.

Fixes #4 