### PR TITLE
Onion routing wireguard

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ expected values are set by default, most with dummy default values.
   Comma-separated list of static IP addresses to assign to the WireGuard
   interface. As far as I know, WireGuard does not currently support DHCP or any
   other form of dynamic IP address assignment.
+- `TUNNEL_ENABLE`:
+  Whether to create the tunnel (veth) network interface between the default
+  (init) and VPN network namespaces. Set to zero to disable or nonzero to
+  enable.
 - `TUNNEL_INIT_NAME`:
   Name to assign to the created tunnel (veth) network interface in the default
   (init) network namespace.
@@ -94,6 +98,12 @@ expected values are set by default, most with dummy default values.
 - `TUNNEL_VPN_IP_ADDRESSES`:
   Comma-separated list of static IP addresses to assign to the tunnel interface
   in the VPN network namespace.
+  
+#### Tunnel
+
+This package provides a tunnel between the init namesapce and the created VPN
+namespace so, e.g., you can control services inside the VPN namespace from
+outside. If you don't need or want the tunnel, just set `TUNNEL_ENABLE=0`.
 
 #### Namespace Overlay
 
@@ -162,7 +172,6 @@ PrivateNetwork=yes
 ## Future Work/TODO
 
 - Consider using `sd_notify` for service scripts to provide a status.
-- Provide a way to disable the tunnel if desired.
 - Once systemd 247 is widely available (probably when Fedora 34 is released),
   switch to using `LoadCredentials=` for the WireGuard private key.
 

--- a/bin/namespaced-wireguard-vpn-interface
+++ b/bin/namespaced-wireguard-vpn-interface
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -o xtrace
+
 die() {
     echo "${BASH_SOURCE[1]}: line ${BASH_LINENO[0]}: ${FUNCNAME[1]}: ${1:-Died}" >&2
     exit 1
@@ -24,13 +26,14 @@ case "$1" in
                 allowed_ips="$WIREGUARD_ALLOWED_IPS"
             fi
 
-            wg set "${wg_names[$i]}" \
+            ip $pre_netns link set "${wg_names[$i]}" netns "${netns_names[$i]}" || die
+
+            ip netns exec "${netns_names[$i]}" wg set "${wg_names[$i]}" \
                 private-key <(echo "${wg_private_keys[$i]}") \
                 peer "${wg_vpn_public_keys[$i]}" \
-                    endpoint "${wg_endpoints[$i}" \
+                    endpoint "${wg_endpoints[$i]}" \
                     allowed-ips "$allowed_ips" || die
 
-            ip link set "${wg_names[$i]}" netns "${netns_names[$i]}" || die
 
             # Addresses are comma-separated, so to split them.
             tr ',' '\n' <<<"$WIREGUARD_IP_ADDRESSES" |

--- a/bin/namespaced-wireguard-vpn-interface
+++ b/bin/namespaced-wireguard-vpn-interface
@@ -17,9 +17,12 @@ case "$1" in
     up)
         pre_netns=""
         allowed_ips="0.0.0.0/0,::0/0"
+        mtu="$WIREGUARD_INITIAL_MTU"
         for (( i=0; i<${#netns_names[*]}; ++i))
         do
-            ip $pre_netns link add "${wg_names[$i]}" type wireguard || die
+            ip $pre_netns link add "${wg_names[$i]}" mtu $mtu type wireguard || die
+            # reduction for worse-case scenario of IPv6
+            mtu=$(($mtu - 80)) 
 
             if [ $(( $i + 1 )) -eq ${#netns_names[*]} ]
             then
@@ -44,7 +47,10 @@ case "$1" in
 
             # Add default routes for IPv4 and IPv6
             ip -n "${netns_names[$i]}" -4 route add default dev "${wg_names[$i]}" || die
-            ip -n "${netns_names[$i]}" -6 route add default dev "${wg_names[$i]}" || die
+            if ip -o -6 -a | grep "${wg_names[$i]}"
+            then
+                ip -n "${netns_names[$i]}" -6 route add default dev "${wg_names[$i]}" || die
+            fi
             pre_netns="-n ${netns_names[$i]}"
         done
         ;;

--- a/bin/namespaced-wireguard-vpn-interface
+++ b/bin/namespaced-wireguard-vpn-interface
@@ -58,7 +58,7 @@ case "$1" in
         # We need to delete the WireGuard interface. It's initially created in
         # the init network namespace, then moved to the VPN namespace.
         # Depending how well the "up" operation went, it might be in either.
-        for (( i=${#netns_names[*]}; i>=0; --i))
+        for (( i=$((${#netns_names[*]} - 1)); i>=0; --i))
         do
             ip -n "${netns_names[$i]}" link delete "${wg_names[$i]}" ||
                 ip link delete "${wg_names[$i]}" || die

--- a/bin/namespaced-wireguard-vpn-interface
+++ b/bin/namespaced-wireguard-vpn-interface
@@ -5,36 +5,55 @@ die() {
     exit 1
 }
 
+netns_names=($NETNS_NAME)
+wg_names=($WIREGUARD_NAME)
+wg_private_keys=($WIREGUARD_PRIVATE_KEY)
+wg_vpn_public_keys=($WIREGUARD_VPN_PUBLIC_KEY)
+wg_endpoints=($WIREGUARD_ENDPOINT)
+
 case "$1" in
     up)
-        ip link add "$WIREGUARD_NAME" type wireguard || die
+        pre_netns=""
+        allowed_ips="0.0.0.0/0,::0/0"
+        for (( i=0; i<${#netns_names[*]}; ++i))
+        do
+            ip $pre_netns link add "${wg_names[$i]}" type wireguard || die
 
-        wg set "$WIREGUARD_NAME" \
-            private-key <(echo "$WIREGUARD_PRIVATE_KEY") \
-            peer "$WIREGUARD_VPN_PUBLIC_KEY" \
-                endpoint "$WIREGUARD_ENDPOINT" \
-                allowed-ips "$WIREGUARD_ALLOWED_IPS" || die
+            if [ $(( $i + 1 )) -eq ${#netns_names[*]} ]
+            then
+                allowed_ips="$WIREGUARD_ALLOWED_IPS"
+            fi
 
-        ip link set "$WIREGUARD_NAME" netns "$NETNS_NAME" || die
+            wg set "${wg_names[$i]}" \
+                private-key <(echo "${wg_private_keys[$i]}") \
+                peer "${wg_vpn_public_keys[$i]}" \
+                    endpoint "${wg_endpoints[$i}" \
+                    allowed-ips "$allowed_ips" || die
 
-        # Addresses are comma-separated, so to split them.
-        tr ',' '\n' <<<"$WIREGUARD_IP_ADDRESSES" |
-            xargs -I '{}' \
-                ip -n "$NETNS_NAME" address add '{}' dev "$WIREGUARD_NAME" || die
+            ip link set "${wg_names[$i]}" netns "${netns_names[$i]}" || die
 
-        ip -n "$NETNS_NAME" link set "$WIREGUARD_NAME" up || die
+            # Addresses are comma-separated, so to split them.
+            tr ',' '\n' <<<"$WIREGUARD_IP_ADDRESSES" |
+                xargs -I '{}' \
+                    ip -n "${netns_names[$i]}" address add '{}' dev "${wg_names[$i]}" || die
 
-        # Add default routes for IPv4 and IPv6
-        ip -n "$NETNS_NAME" -4 route add default dev "$WIREGUARD_NAME" || die
-        ip -n "$NETNS_NAME" -6 route add default dev "$WIREGUARD_NAME" || die
+            ip -n "${netns_names[$i]}" link set "${wg_names[$i]}" up || die
+
+            # Add default routes for IPv4 and IPv6
+            ip -n "${netns_names[$i]}" -4 route add default dev "${wg_names[$i]}" || die
+            ip -n "${netns_names[$i]}" -6 route add default dev "${wg_names[$i]}" || die
+            pre_netns="-n ${netns_names[$i]}"
+        done
         ;;
-
     down)
         # We need to delete the WireGuard interface. It's initially created in
         # the init network namespace, then moved to the VPN namespace.
         # Depending how well the "up" operation went, it might be in either.
-        ip -n "$NETNS_NAME" link delete "$WIREGUARD_NAME" ||
-            ip link delete "$WIREGUARD_NAME" || die
+        for (( i=${#netns_names[*]}; i>=0; --i))
+        do
+            ip -n "${netns_names[$i]}" link delete "${wg_names[$i]}" ||
+                ip link delete "${wg_names[$i]}" || die
+        done
         ;;
 esac
 

--- a/bin/namespaced-wireguard-vpn-netns
+++ b/bin/namespaced-wireguard-vpn-netns
@@ -7,7 +7,10 @@ die() {
 
 case "$1" in
     up)
-        ip netns add "$NETNS_NAME" || die
+        for name in $NETNS_NAME
+        do
+            ip netns add $name || die
+        done
 
         if [[ -n "$PRIVATE_NETNS_BIND_MOUNT" ]]
         then
@@ -15,11 +18,17 @@ case "$1" in
             mount --bind "$PRIVATE_NETNS_BIND_MOUNT" "/var/run/netns/$NETNS_NAME" || die
         fi
 
-        ip -n "$NETNS_NAME" link set lo up || die
+        for name in $NETNS_NAME
+        do
+            ip -n $name link set lo up || die
+        done
         ;;
 
     down)
-        ip netns delete "$NETNS_NAME" || die
+        for name in $NETNS_NAME
+        do
+            ip netns delete $name || die
+        done
         ;;
 esac
 

--- a/bin/namespaced-wireguard-vpn-netns
+++ b/bin/namespaced-wireguard-vpn-netns
@@ -10,18 +10,16 @@ case "$1" in
         for name in $NETNS_NAME
         do
             ip netns add $name || die
+
+            ip -n $name link set lo up || die
+            last=$name
         done
 
         if [[ -n "$PRIVATE_NETNS_BIND_MOUNT" ]]
         then
-            umount "/var/run/netns/$NETNS_NAME" || die
-            mount --bind "$PRIVATE_NETNS_BIND_MOUNT" "/var/run/netns/$NETNS_NAME" || die
+            umount "/var/run/netns/$last" || die
+            mount --bind "$PRIVATE_NETNS_BIND_MOUNT" "/var/run/netns/$last" || die
         fi
-
-        for name in $NETNS_NAME
-        do
-            ip -n $name link set lo up || die
-        done
         ;;
 
     down)

--- a/bin/namespaced-wireguard-vpn-tunnel
+++ b/bin/namespaced-wireguard-vpn-tunnel
@@ -5,8 +5,8 @@ die() {
     exit 1
 }
 
-arr=($NETNS_NAME)
-main_netns=${arr[-1]}
+netns_names=($NETNS_NAME)
+main_netns=${netns_names[-1]}
 
 case "$1" in
     up)

--- a/bin/namespaced-wireguard-vpn-tunnel
+++ b/bin/namespaced-wireguard-vpn-tunnel
@@ -5,10 +5,13 @@ die() {
     exit 1
 }
 
+arr=($NETNS_NAME)
+main_netns=${arr[-1]}
+
 case "$1" in
     up)
         ip link add "$TUNNEL_INIT_NAME" type veth \
-            peer "$TUNNEL_VPN_NAME" netns "$NETNS_NAME" || die
+            peer "$TUNNEL_VPN_NAME" netns "$main_netns" || die
 
         # Addresses are comma-separated, so to split them.
         tr ',' '\n' <<<"$TUNNEL_INIT_IP_ADDRESSES" |
@@ -16,16 +19,16 @@ case "$1" in
                 ip address add '{}' dev "$TUNNEL_INIT_NAME" || die
         tr ',' '\n' <<<"$TUNNEL_VPN_IP_ADDRESSES" |
             xargs -I '{}' \
-                ip -n "$NETNS_NAME" address add '{}' dev "$TUNNEL_VPN_NAME" || die
+                ip -n "$main_netns" address add '{}' dev "$TUNNEL_VPN_NAME" || die
 
         ip link set "$TUNNEL_INIT_NAME" up || die
-        ip -n "$NETNS_NAME" link set "$TUNNEL_VPN_NAME" up || die
+        ip -n "$main_netns" link set "$TUNNEL_VPN_NAME" up || die
         ;;
 
     down)
         EXIT_CODE=0
         ip link delete "$TUNNEL_INIT_NAME" || EXIT_CODE=$?
-        ip -n "$NETNS_NAME" link delete "$TUNNEL_VPN_NAME" || EXIT_CODE=$?
+        ip -n "$main_netns" link delete "$TUNNEL_VPN_NAME" || EXIT_CODE=$?
         [[ EXIT_CODE -eq 0 ]] || die
         ;;
 esac

--- a/conf/namespaced-wireguard-vpn.conf
+++ b/conf/namespaced-wireguard-vpn.conf
@@ -20,6 +20,9 @@ WIREGUARD_ALLOWED_IPS=0.0.0.0/0,::0/0
 # interface
 WIREGUARD_IP_ADDRESSES=10.0.0.1/32,fd12:3456:789a:1::1/128
 
+# Enable the tunnel interface
+TUNNEL_ENABLE=1
+
 # Name of the init-facing tunnel interface
 TUNNEL_INIT_NAME=veth-vpn0
 

--- a/conf/namespaced-wireguard-vpn.conf
+++ b/conf/namespaced-wireguard-vpn.conf
@@ -20,6 +20,12 @@ WIREGUARD_ALLOWED_IPS=0.0.0.0/0,::0/0
 # interface
 WIREGUARD_IP_ADDRESSES=10.0.0.1/32,fd12:3456:789a:1::1/128
 
+# Assuming a sane VPN provider:
+# IPv4: 1440
+# IPv6: 1420
+# If using PPPoE(typically DSL) -=8
+WIREGUARD_INITIAL_MTU=1420
+
 # Enable the tunnel interface
 TUNNEL_ENABLE=1
 

--- a/systemd/namespaced-wireguard-vpn-tunnel.service
+++ b/systemd/namespaced-wireguard-vpn-tunnel.service
@@ -10,6 +10,8 @@ RemainAfterExit=yes
 
 EnvironmentFile=/etc/namespaced-wireguard-vpn/namespaced-wireguard-vpn.conf
 
+ExecCondition=/usr/bin/test "$TUNNEL_ENABLE" -ne 0
+
 ExecStart=/usr/sbin/namespaced-wireguard-vpn-tunnel up
 ExecStopPost=/usr/sbin/namespaced-wireguard-vpn-tunnel down
 


### PR DESCRIPTION
One of the things that are made especially easy by using namespaces is to layer multiple wireguard connections inside of one another. Normally stacking VPN connections like this is done through things like having multiple separate VPN gateways that are each using each other, but namespaces make this far simpler and eliminate the need for having multiple VMs or the like.

Stacking VPN connections like this allows for potentially enhanced security, as there are now additional points of failure.

This PR adds this functionality to the services. It can be used by simply adding further wireguard connection information to the first 5 keys in the config file, each being separated by a space.

Submitting this as WIP as I have yet to fix up the documentation, but as my bash is... lacking to say the least I'd appreciate some comments wrt any potential issues that might arise from this implementation.

My branch also includes the deactivation of the tunnel from your other branch, as that would be handy for my usecase. If there is any reason you do not want to merge that alongside this functionality already I can rebase everything. Same applies if you require a cleaner commit history.

Performance is not horrible with good VPN providers actually. 250Mb/s+ are possible(My home connection is 1Gb/s). It could be better and I do think some tuning to the MTUs could further improve what I'm seeing but it's certainly far better than the likes of TOR even when also using 3 layers.