### PR TITLE
Only add ipv6 route if available and set MTU directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ expected values are set by default, most with dummy default values.
   WireGuard interface. For a namespaced VPN, where the goal is to force all
   traffic through the VPN, the catch-all value `0.0.0.0/0,::0/0` is probably
   correct.
+- `WIREGUARD_INITIAL_MTU`:
+  MTU of the wireguard interface. Choosing too large a value risks packet loss.
 - `WIREGUARD_IP_ADDRESSES`:
   Comma-separated list of static IP addresses to assign to the WireGuard
   interface. As far as I know, WireGuard does not currently support DHCP or any

--- a/bin/namespaced-wireguard-vpn-interface
+++ b/bin/namespaced-wireguard-vpn-interface
@@ -7,7 +7,7 @@ die() {
 
 case "$1" in
     up)
-        ip link add "$WIREGUARD_NAME" type wireguard || die
+        ip link add "$WIREGUARD_NAME" mtu $WIREGUARD_INITIAL_MTU type wireguard || die
 
         wg set "$WIREGUARD_NAME" \
             private-key <(echo "$WIREGUARD_PRIVATE_KEY") \
@@ -26,7 +26,10 @@ case "$1" in
 
         # Add default routes for IPv4 and IPv6
         ip -n "$NETNS_NAME" -4 route add default dev "$WIREGUARD_NAME" || die
-        ip -n "$NETNS_NAME" -6 route add default dev "$WIREGUARD_NAME" || die
+        if ip -o -6 -a | grep -q "$WIREGUARD_NAME"
+        then 
+            ip -n "$NETNS_NAME" -6 route add default dev "$WIREGUARD_NAME" || die
+        fi
         ;;
 
     down)

--- a/conf/namespaced-wireguard-vpn.conf
+++ b/conf/namespaced-wireguard-vpn.conf
@@ -20,6 +20,12 @@ WIREGUARD_ALLOWED_IPS=0.0.0.0/0,::0/0
 # interface
 WIREGUARD_IP_ADDRESSES=10.0.0.1/32,fd12:3456:789a:1::1/128
 
+# Assuming a sane VPN provider:
+# IPv4: 1440
+# IPv6: 1420
+# If using PPPoE(typically DSL) -=8
+WIREGUARD_INITIAL_MTU=1420
+
 # Name of the init-facing tunnel interface
 TUNNEL_INIT_NAME=veth-vpn0
 


### PR DESCRIPTION
Alright here's the MTU change as a separate PR, also added in that IPv6 routes should only be added if there is an actual IPv6 address available, that was giving me trouble while I was testing for the other PR.