### PR TITLE
Document #7 and add preshared key functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ expected values are set by default, most with dummy default values.
   The endpoint of the VPN provider's WireGuard server.
 - `WIREGUARD_VPN_PUBLIC_KEY`:
   The public key of the VPN provider's WireGuard peer.
+- `WIREGUARD_VPN_PPRESHARED_KEY`:
+  The preshared key of the VPN provider's WireGuard peer. Set to - to disable.
 - `WIREGUARD_ALLOWED_IPS`:
   Comma-separated list of IP addresses that may be contacted using the
   WireGuard interface. For a namespaced VPN, where the goal is to force all

--- a/README.md
+++ b/README.md
@@ -159,7 +159,10 @@ $ ip netns exec $NETNS_NAME nslookup example.com
 While `ip netns exec` is handy for one-off commands, this project is most
 useful to allow running other systemd units in a VPN-only namespace. This is accomplished by
 adding a drop-in override file to the unit. In the following example, we'll configure
-Transmission Daemon to run in our namespace.
+Transmission Daemon to run in our namespace. Beware that is used in conjunction with the 
+`nsswitch.conf` and `resolv.conf` tweaks above this will not work correctly, as systemd
+does not mount them into the right locations. There using `ip netns exec` may be more
+appropriate.
 
 #### `/etc/systemd/system/transmission-daemon.service.d/10-vpn-netns.conf`:
 

--- a/bin/namespaced-wireguard-vpn-interface
+++ b/bin/namespaced-wireguard-vpn-interface
@@ -9,11 +9,21 @@ case "$1" in
     up)
         ip link add "$WIREGUARD_NAME" mtu $WIREGUARD_INITIAL_MTU type wireguard || die
 
-        wg set "$WIREGUARD_NAME" \
-            private-key <(echo "$WIREGUARD_PRIVATE_KEY") \
-            peer "$WIREGUARD_VPN_PUBLIC_KEY" \
-                endpoint "$WIREGUARD_ENDPOINT" \
-                allowed-ips "$WIREGUARD_ALLOWED_IPS" || die
+        if [ "$WIREGUARD_VPN_PRESHARED_KEY" == "-" ]
+        then
+            wg set "$WIREGUARD_NAME" \
+                private-key <(echo "$WIREGUARD_PRIVATE_KEY") \
+                peer "$WIREGUARD_VPN_PUBLIC_KEY" \
+                    endpoint "$WIREGUARD_ENDPOINT" \
+                    allowed-ips "$WIREGUARD_ALLOWED_IPS" || die
+        else
+            wg set "$WIREGUARD_NAME" \
+                private-key <(echo "$WIREGUARD_PRIVATE_KEY") \
+                peer "$WIREGUARD_VPN_PUBLIC_KEY" \
+                preshared-key <(echo "$WIREGUARD_VPN_PRESHARED_KEY") \
+                    endpoint "$WIREGUARD_ENDPOINT" \
+                    allowed-ips "$WIREGUARD_ALLOWED_IPS" || die
+        fi
 
         ip link set "$WIREGUARD_NAME" netns "$NETNS_NAME" || die
 

--- a/conf/namespaced-wireguard-vpn.conf
+++ b/conf/namespaced-wireguard-vpn.conf
@@ -13,6 +13,9 @@ WIREGUARD_ENDPOINT=1.2.3.4:56789
 # Public key of the VPN WireGuard peer
 WIREGUARD_VPN_PUBLIC_KEY=abcdFAKEefghFAKEijklFAKEmnopFAKEqrstFAKEuvw=
 
+# Preshared key of the VPN WireGuard peer, set to - to disable
+WIREGUARD_VPN_PRESHARED_KEY=-
+
 # Comma-separated list of allowed IP addresses for the VPN WireGuard interface
 WIREGUARD_ALLOWED_IPS=0.0.0.0/0,::0/0
 


### PR DESCRIPTION
Preshared keys are used by default by some VPN providers, so this may be useful.

So far I only added a documentation note about #7, but potentially that functionality could be removed entirely as suggested there.

I also added a note about the possibility of routing things into the VPN namespace from the rest of the local network using iptables.