### PR TITLE
PrivateNetwork=yes implies PrivateMounts=yes in systemd 254, we need PrivateMounts=no for namespaces to work

### DIFF
--- a/systemd/namespaced-wireguard-vpn-netns.service
+++ b/systemd/namespaced-wireguard-vpn-netns.service
@@ -10,6 +10,7 @@ After=network.target
 Type=oneshot
 RemainAfterExit=yes
 PrivateNetwork=yes
+PrivateMounts=no
 
 Environment=PRIVATE_NETNS_BIND_MOUNT=/proc/self/ns/net
 EnvironmentFile=/etc/namespaced-wireguard-vpn/namespaced-wireguard-vpn.conf


### PR DESCRIPTION
This is visible in `namespaced-wireguard-vpn-interface.service` failing to set the namespace on the wireguard interface, with:

```
RTNETLINK answers: Invalid argument
/usr/sbin/namespaced-wireguard-vpn-interface: line 19: main: Died
Main process exited, code=exited, status=1/FAILURE
setting the network namespace "pia" failed: Invalid argument
```

See also https://github.com/systemd/systemd/blob/6f420b5f75a33de2ac9ecf6e08b30cae9246b062/NEWS#L93-L94 and https://bugs.archlinux.org/task/79341